### PR TITLE
Fixed #7 - Include 'e' option in substitute

### DIFF
--- a/plugin/titlecase.vim
+++ b/plugin/titlecase.vim
@@ -21,7 +21,7 @@ function! s:titlecase(type, ...) abort
       silent execute 'normal! ' . a:type . '`>"ip'
     endif
   elseif a:type == 'line'
-    execute '''[,'']s/'.WORD_PATTERN.'/'.UPCASE_REPLACEMENT.'/g' 
+    execute '''[,'']s/'.WORD_PATTERN.'/'.UPCASE_REPLACEMENT.'/ge'
   else
     silent exe "normal! `[v`]y"
     let titlecased = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')


### PR DESCRIPTION
Ignores error message when WORD_PATTERN is not found.