### PR TITLE
Added documentation text and :Titlecase command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ titlecase operation. This means `gti'` will titlecase inside of single quotes,
 `gtap` will titlecase a paragraph, etc. `gt` will also work on a visual
 selection.
 
-In addition, `gT` will titlecase the current line.
+In addition, `gT` or `gtt` will titlecase the current line.
 
 Mappings
 --------
 
-Be default titlecase maps itself to `gt`, but this interferes with the default
+By default titlecase maps itself to `gt`, but this interferes with the default
 mapping for switching tabs. If you would like to disable the default maps, add
 the following to your vimrc:
 

--- a/doc/titlecase.txt
+++ b/doc/titlecase.txt
@@ -1,0 +1,49 @@
+*vim-titlecase* *titlecase.txt*    Commands for titlecasing portions of text
+
+==============================================================================
+Overview
+
+Titlecase is a vim plugin that adds a new |operator| (command that takes a
+text object or motion to act on) for titlecasing text. >
+      this is some text  |  this is Some text
+    method('some args')  |  method('Some Args')
+           a title line  |   A Title Line
+<
+
+==============================================================================
+Mappings                                                  *titlecase-mappings*
+
+                                                        *g:titlecase_map_keys*
+Be default titlecase maps itself to `gt`, but this interferes with the default
+mapping for switching tabs. If you would like to disable the default maps, add
+the following to your vimrc: >
+    let g:titlecase_map_keys = 0
+<
+
+To add other mappings, you can add something like the following to your
+|vimrc|: >
+    "<Plug>Titlecase titlecases the region defined by a text object or motion
+    nmap <leader>gt <Plug>Titlecase
+    vmap <leader>gt <Plug>Titlecase
+    "<Plug>TitlecaseLine titlecases the entire line
+    nmap <leader>gT <Plug>TitlecaseLine
+<
+
+gt{motion}                                                      *titlecase-gt*
+                The `gt` mapping will wait for a |text-object| or |motion|
+                before completing the titlecase operation. This means `gti'`
+                will titlecase inside of single quotes, `gtap` will titlecase
+                a paragraph, etc. |v_gt| will also work on a visual selection.
+
+gT or gtt                                       *titlecase-gtt* *titlecase-gT*
+                Titlecase an entire line.
+
+{Visual}gt                                                              *v_gt*
+                Titlecase the selected text. See |titlecase-gt|.
+
+:[range]Titlecase                                                 *:Titlecase*
+                Titlecase each line in [range], or the current line if [range]
+                is omitted.
+
+==============================================================================
+vim:tw=78:fo=tcq2:syntax=help:

--- a/plugin/titlecase.vim
+++ b/plugin/titlecase.vim
@@ -37,7 +37,7 @@ xnoremap <silent> <Plug>Titlecase :<C-U> call <SID>titlecase(visualmode(),visual
 nnoremap <silent> <Plug>Titlecase :<C-U>set opfunc=<SID>titlecase<CR>g@
 nnoremap <silent> <Plug>TitlecaseLine :<C-U>set opfunc=<SID>titlecase<Bar>exe 'norm! 'v:count1.'g@_'<CR>
 
-command -range Titlecase call <SID>titlecase('V', <line1>, <line2>)
+command! -range Titlecase call <SID>titlecase('V', <line1>, <line2>)
 
 if g:titlecase_map_keys
   nmap gt <Plug>Titlecase

--- a/plugin/titlecase.vim
+++ b/plugin/titlecase.vim
@@ -9,7 +9,11 @@ function! s:titlecase(type, ...) abort
   let WORD_PATTERN = '\<\(\k\)\(\k*''*\k*\)\>'
   let UPCASE_REPLACEMENT = '\u\1\L\2'
 
-  if a:0  " Invoked from Visual mode, use '< and '> marks.
+  if a:0 == 2 " Invoked from command with range
+    let l:line1 = a:1
+    let l:line2 = a:2
+    silent exe "normal! " . l:line1 . "GV" . l:line2 . "G:\<C-U> call \<SID>titlecase('V', 1)\<CR>"
+  elseif a:0  " Invoked from Visual mode, use '< and '> marks.
     if a:type == ''
       silent exe "normal! `<" . a:type . "`>y"
       let titlecased = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
@@ -33,8 +37,12 @@ xnoremap <silent> <Plug>Titlecase :<C-U> call <SID>titlecase(visualmode(),visual
 nnoremap <silent> <Plug>Titlecase :<C-U>set opfunc=<SID>titlecase<CR>g@
 nnoremap <silent> <Plug>TitlecaseLine :<C-U>set opfunc=<SID>titlecase<Bar>exe 'norm! 'v:count1.'g@_'<CR>
 
+command -range Titlecase call <SID>titlecase('V', <line1>, <line2>)
+
 if g:titlecase_map_keys
   nmap gt <Plug>Titlecase
   vmap gt <Plug>Titlecase
   nmap gT <Plug>TitlecaseLine
+  " compatible with eg. yy and cc and gqq
+  nmap gtt <Plug>TitlecaseLine
 endif


### PR DESCRIPTION
* Added doc/titlecase.txt for help.
* Added :Titlecase command which accepts a range and title-cases the
  current line (default) or the range of lines (if two lines are given)
* Added `gtt` command to line up with `gqq`, `yy`, `cc`
