### PR TITLE
Autoloading function and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,34 +12,27 @@ Usage
 -----
 
 The main interface to the plugin is via the `<Plug>Titlecase` operator, by
-default mapped to `gt`.
+default mapped to `gz`.
 
-The `gt` mapping will wait for a text object or motion before completing the
-titlecase operation. This means `gti'` will titlecase inside of single quotes,
-`gtap` will titlecase a paragraph, etc. `gt` will also work on a visual
+The `gz` mapping will wait for a text object or motion before completing the
+titlecase operation. This means `gzi'` will titlecase inside of single quotes,
+`gzap` will titlecase a paragraph, etc. `gz` will also work on a visual
 selection.
 
-In addition, `gT` will titlecase the current line.
+In addition, `gzz` will titlecase the current line.
 
 Mappings
 --------
 
-Be default titlecase maps itself to `gt`, but this interferes with the default
-mapping for switching tabs. If you would like to disable the default maps, add
-the following to your vimrc:
+Be default titlecase maps itself to `gz`. 
+If you would like to disable the default maps, add the following to your vimrc:
 
 ``` vim
 Bundle 'christoomey/vim-titlecase'
 
-let g:titlecase_map_keys = 0
-```
-
-You can then add any mappings you would like with the following:
-
-``` vim
-nmap <leader>gt <Plug>Titlecase
-vmap <leader>gt <Plug>Titlecase
-nmap <leader>gT <Plug>TitlecaseLine
+nmap <leader>gz  <Plug>Titlecase
+vmap <leader>gz  <Plug>Titlecase
+nmap <leader>gzz <Plug>TitlecaseLine
 ```
 
 ``` vim

--- a/autoload/titlecase.vim
+++ b/autoload/titlecase.vim
@@ -1,3 +1,10 @@
+" autoload/titlecase.vim
+
+if exists('g:autoloaded_titlecase')
+  finish
+endif
+let g:autoloaded_titlecase = 1
+
 let s:titlecase_excluded_words = get(g:, 'titlecase_excluded_words', [])
 let s:local_exclusion_list = deepcopy(s:titlecase_excluded_words)
 call map(s:local_exclusion_list, 'tolower(v:val)')

--- a/autoload/titlecase.vim
+++ b/autoload/titlecase.vim
@@ -1,0 +1,55 @@
+let s:titlecase_excluded_words = get(g:, 'titlecase_excluded_words', [])
+let s:local_exclusion_list = deepcopy(s:titlecase_excluded_words)
+call map(s:local_exclusion_list, 'tolower(v:val)')
+
+function! s:capitalize(string)
+  " Don't change intentional all caps
+  if(toupper(a:string) ==# a:string)
+    return a:string
+  endif
+
+  let s = tolower(a:string)
+
+  let exclusions = '^\(a\|an\|and\|as\|at\|but\|by\|en\|for\|if\|in\|nor\|of\|on\|or\|per\|the\|to\|v.?\|vs.?\|via\)$'
+  " Return the lowered string if it matches either the built-in or user exclusion list
+  if (match(s, exclusions) >= 0) || (index(s:local_exclusion_list, s) >= 0)
+    return s
+  endif
+
+  return toupper(s[0]) . s[1:]
+endfunction
+
+function! titlecase#titlecase(type, ...) abort
+  let WORD_PATTERN = '\<\(\k\)\(\k*''*\k*\)\>'
+  " calls s:capitalize with the whole pattern match
+  let UPCASE_REPLACEMENT = '\=s:capitalize(submatch(0))'
+
+  let regbak = @@
+  try
+    if a:0  " Invoked from Visual mode, use '< and '> marks.
+      " Back up unnamed register to avoid clobbering its contents
+      if a:type == ''
+        silent exe "normal! `<" . a:type . "`>y"
+        let titlecased = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
+        call setreg('@', titlecased, 'b')
+        silent execute 'normal! ' . a:type . '`>p'
+      else
+        silent exe "normal! `<" . a:type . "`>y"
+        let @i = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
+        silent execute 'normal! ' . a:type . '`>"ip'
+      endif
+    elseif a:type == 'line'
+      execute '''[,'']s/'.WORD_PATTERN.'/'.UPCASE_REPLACEMENT.'/ge'
+      " Always capitalize the start and end
+      execute '''[,'']s/'.WORD_PATTERN.'/\u\1\L\2/e'
+      execute '''[,'']s/'.WORD_PATTERN.'\(\K*\)$/\u\1\L\2\e\3/e'
+    else
+      silent exe "normal! `[v`]y"
+      let titlecased = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
+      silent exe "normal! v`]c" . titlecased
+    endif
+  finally
+    " Restore unnamed register to its original state
+    let @@ = regbak
+  endtry
+endfunction

--- a/plugin/titlecase.vim
+++ b/plugin/titlecase.vim
@@ -5,15 +5,12 @@ xnoremap <silent> <Plug>Titlecase
 nnoremap <silent> <Plug>TitlecaseLine
       \ :<C-U>set opfunc=titlecase#titlecase<Bar>exe 'normal! ' . v:count1 . 'g@_'<CR>
 
-let s:titlecase_map_keys = get(g:, 'titlecase_map_keys', 1)
-if s:titlecase_map_keys
-  if !hasmapto('<Plug>Titlecase', 'n') && maparg('gt', 'n') ==# ''
-    nmap gt <Plug>Titlecase
-  endif
-  if !hasmapto('<Plug>Titlecase', 'x') && maparg('gt', 'x') ==# ''
-    xmap gt <Plug>Titlecase
-  endif
-  if !hasmapto('<Plug>TitlecaseLine', 'n') && maparg('gT', 'n') ==# ''
-    nmap gT <Plug>TitlecaseLine
-  endif
+if !hasmapto('<Plug>Titlecase', 'n') && maparg('gz', 'n') ==# ''
+  nmap gz <Plug>Titlecase
+endif
+if !hasmapto('<Plug>Titlecase', 'x') && maparg('gz', 'x') ==# ''
+  xmap gz <Plug>Titlecase
+endif
+if !hasmapto('<Plug>TitlecaseLine', 'n') && maparg('gzz', 'n') ==# ''
+  nmap gzz <Plug>TitlecaseLine
 endif

--- a/plugin/titlecase.vim
+++ b/plugin/titlecase.vim
@@ -1,75 +1,19 @@
-if !exists('g:titlecase_map_keys')
-  let g:titlecase_map_keys = 1
-endif
+nnoremap <silent> <Plug>Titlecase
+      \ :<C-U>set opfunc=titlecase#titlecase<CR>g@
+xnoremap <silent> <Plug>Titlecase
+      \ :<C-U> call titlecase#titlecase(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
+nnoremap <silent> <Plug>TitlecaseLine
+      \ :<C-U>set opfunc=titlecase#titlecase<Bar>exe 'normal! ' . v:count1 . 'g@_'<CR>
 
-let s:local_exclusion_list = []
-if exists('g:titlecase_excluded_words')
-    let s:local_exclusion_list = deepcopy(g:titlecase_excluded_words)
-    call map(s:local_exclusion_list, 'tolower(v:val)')
-endif
-
-function! s:capitalize(string)
-    " Don't change intentional all caps
-    if(toupper(a:string) ==# a:string)
-        return a:string
-    endif
-
-    let s = tolower(a:string)
-
-    let exclusions = '^\(a\|an\|and\|as\|at\|but\|by\|en\|for\|if\|in\|nor\|of\|on\|or\|per\|the\|to\|v.?\|vs.?\|via\)$'
-    " Return the lowered string if it matches either the built-in or user exclusion list
-    if (match(s, exclusions) >= 0) || (index(s:local_exclusion_list, s) >= 0)
-        return s
-    endif
-
-    return toupper(s[0]) . s[1:]
-endfunction
-
-
-function! s:titlecase(type, ...) abort
-  let g:type = a:type
-  let g:it =  a:0
-  let g:dem = a:000
-  let WORD_PATTERN = '\<\(\k\)\(\k*''*\k*\)\>'
-  " calls s:capitalize with the whole pattern match
-  let UPCASE_REPLACEMENT = '\=s:capitalize(submatch(0))'
-
-  let regbak = @@
-  try
-    if a:0  " Invoked from Visual mode, use '< and '> marks.
-      " Back up unnamed register to avoid clobbering its contents
-      if a:type == ''
-        silent exe "normal! `<" . a:type . "`>y"
-        let titlecased = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
-        call setreg('@', titlecased, 'b')
-        silent execute 'normal! ' . a:type . '`>p'
-      else
-        silent exe "normal! `<" . a:type . "`>y"
-        let @i = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
-        silent execute 'normal! ' . a:type . '`>"ip'
-      endif
-    elseif a:type == 'line'
-      execute '''[,'']s/'.WORD_PATTERN.'/'.UPCASE_REPLACEMENT.'/ge'
-      " Always capitalize the start and end
-      execute '''[,'']s/'.WORD_PATTERN.'/\u\1\L\2/e'
-      execute '''[,'']s/'.WORD_PATTERN.'\(\K*\)$/\u\1\L\2\e\3/e'
-    else
-      silent exe "normal! `[v`]y"
-      let titlecased = substitute(@@, WORD_PATTERN, UPCASE_REPLACEMENT, 'g')
-      silent exe "normal! v`]c" . titlecased
-    endif
-  finally
-    " Restore unnamed register to its original state
-    let @@ = regbak
-  endtry
-endfunction
-
-xnoremap <silent> <Plug>Titlecase :<C-U> call <SID>titlecase(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
-nnoremap <silent> <Plug>Titlecase :<C-U>set opfunc=<SID>titlecase<CR>g@
-nnoremap <silent> <Plug>TitlecaseLine :<C-U>set opfunc=<SID>titlecase<Bar>exe 'norm! 'v:count1.'g@_'<CR>
-
-if g:titlecase_map_keys
-  nmap gt <Plug>Titlecase
-  vmap gt <Plug>Titlecase
-  nmap gT <Plug>TitlecaseLine
+let s:titlecase_map_keys = get(g:, 'titlecase_map_keys', 1)
+if s:titlecase_map_keys
+  if !hasmapto('<Plug>Titlecase', 'n') && maparg('gt', 'n') ==# ''
+    nmap gt <Plug>Titlecase
+  endif
+  if !hasmapto('<Plug>Titlecase', 'x') && maparg('gt', 'x') ==# ''
+    xmap gt <Plug>Titlecase
+  endif
+  if !hasmapto('<Plug>TitlecaseLine', 'n') && maparg('gT', 'n') ==# ''
+    nmap gT <Plug>TitlecaseLine
+  endif
 endif

--- a/plugin/titlecase.vim
+++ b/plugin/titlecase.vim
@@ -1,3 +1,10 @@
+" plugin/titlecase.vim
+
+if exists('g:loaded_titlecase')
+  finish
+endif
+let g:loaded_titlecase = 1
+
 nnoremap <silent> <Plug>Titlecase
       \ :<C-U>set opfunc=titlecase#titlecase<CR>g@
 xnoremap <silent> <Plug>Titlecase


### PR DESCRIPTION
- division of plugin with autoload (function are loaded only if used)
- removed unused global variable in the main function (titlecase)
- avoid use of `if global variable exist` in favour of get, so that global
  variable are defined only if the user actually use them, in this way the
  global namespace is not cluttered
- Additional layer of protection of mapping with hasmapto and maparg and moved
  vmap to xmap
- Please consider to use gz and gzz(for line), which are by default unmapped,
 instead of gt and gT, which are already used for navigating vim tabs, as default mappings.
 (If you agree on that I have ready the pull request)
